### PR TITLE
[#12]Fix: 현재 달력에 이전 달의 날짜가 잘못표시된 이슈 수정

### DIFF
--- a/client/src/components/calendar/content/CalendarContent.tsx
+++ b/client/src/components/calendar/content/CalendarContent.tsx
@@ -30,11 +30,7 @@ const CalendarContent: FC<CalendarContentProps> = ({
         {[...Array(monthYear.firstDOW)].map((_, i) => (
           <Date
             key={i}
-            date={dayjs(
-              `${monthYear.year}${monthYear.month}${
-                monthYear.prevMonthLastDate - monthYear.firstDOW + 1 + i
-              }`
-            )}
+            date={monthYear.firstWeekPrevMonthDate.add(i, "d")}
             disabled
             selectDate={selectDate}
           ></Date>
@@ -42,7 +38,7 @@ const CalendarContent: FC<CalendarContentProps> = ({
         {[...Array(monthYear.lastDate)].map((_, i) => (
           <Date
             key={i}
-            date={dayjs(`${monthYear.year}${monthYear.month}${i + 1}`)}
+            date={monthYear.startDate.add(i, "d")}
             isSelectedDate={dayjs(
               `${monthYear.year}${monthYear.month}${i + 1}`
             ).isSame(selectedDate)}
@@ -54,7 +50,7 @@ const CalendarContent: FC<CalendarContentProps> = ({
         ].map((_, i) => (
           <Date
             key={i}
-            date={dayjs(`${monthYear.year}${monthYear.month}${i + 1}`)}
+            date={monthYear.nextMonthStartDate.add(i, "d")}
             disabled
             selectDate={selectDate}
           />

--- a/client/src/types/calendar.ts
+++ b/client/src/types/calendar.ts
@@ -2,6 +2,9 @@ import dayjs from "dayjs";
 
 export interface MonthYear {
   startDate: dayjs.Dayjs;
+  prevMonthStartDate: dayjs.Dayjs;
+  nextMonthStartDate: dayjs.Dayjs;
+  firstWeekPrevMonthDate: dayjs.Dayjs;
   firstDOW: number;
   lastDate: number;
   prevMonthLastDate: number;

--- a/client/src/utils/helper/monthYear.ts
+++ b/client/src/utils/helper/monthYear.ts
@@ -15,15 +15,23 @@ export const getMonthYearDetails = (initialDate: dayjs.Dayjs): MonthYear => {
   const date = initialDate.format("DD");
   const dayOfWeek = initialDate.format("dddd");
   const startDate = dayjs(`${year}${month}01`);
+  const prevMonthStartDate = startDate.clone().subtract(1, "month");
+  const nextMonthStartDate = startDate.clone().add(1, "month");
   const firstDOW = Number(startDate.format("d"));
   const lastDate = Number(startDate.clone().endOf("month").format("DD"));
   const monthName = startDate.format("MMMM");
   const prevMonthLastDate = Number(
-    startDate.clone().subtract(1, "month").endOf("month").format("DD")
+    prevMonthStartDate.endOf("month").format("DD")
+  );
+  const firstWeekPrevMonthDate = prevMonthStartDate.set(
+    "date",
+    prevMonthLastDate - firstDOW + 1
   );
 
   return {
     startDate,
+    prevMonthStartDate,
+    nextMonthStartDate,
     firstDOW,
     lastDate,
     monthName,
@@ -32,6 +40,7 @@ export const getMonthYearDetails = (initialDate: dayjs.Dayjs): MonthYear => {
     month,
     year,
     prevMonthLastDate,
+    firstWeekPrevMonthDate,
   };
 };
 


### PR DESCRIPTION
## 📎 관련 이슈

- #12 
  <br/>

## ✔️ 셀프 체크리스트

> 최소 1명 이상의 assign을 받아야만 Merge 가능합니다.

- [x] 내 코드가 프로젝트의 스타일가이드를 따르고 있는가?
- [x] 스스로 자신의 코드를 리뷰했는가?
- [x] 내가 만든 변화가 새로운 warning을 만들지 않는가?
- [x] 3C 를 만족하였는가? (console.log 삭제, 주석 삭제, 중복 코드 제거)

## 💬 작업내용

> 구현 내용 및 작업 했던 내역
- monthYear 데이터에 이전 달, 다음 달 관련 데이터 추가
- 캘린더 날짜 표시 데이터 map 함수 로직 리팩토링

<br/>

## 🚧 PR 특이 사항

> PR을 볼 때 주의깊게 봐야하거나 말하고 싶은점
- monthYear 데이터에 이전 달, 다음 달 관련 데이터 추가
- 캘린더 날짜 표시 데이터 map 함수 로직 리팩토링


<br/>
